### PR TITLE
get inactive groups with turnid

### DIFF
--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -35,6 +35,11 @@ export class GroupsController {
     return this.groupsProvider.getGroupsWithTurn();
   }
 
+  @Get('/turn/:id/inactive')
+  getInactiveGroupsWithTurnid(@Param('id') turnId: number) {
+    return this.groupsProvider.getInactiveGroupsWithTurnid(turnId);
+  }
+
   @Get('/:id')
   getGroup(@Param('id') groupId: number) {
     return this.groupsProvider.getGroup(groupId);

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -28,6 +28,15 @@ export class GroupsProvider {
     return await this.groupService.find({ relations: ['turn'] });
   }
 
+  async getInactiveGroupsWithTurnid(turnId: number) {
+    const turnFound = await this.turnService.findOne({ where: { id: turnId } });
+    if (!turnFound)
+      return new HttpException('Turn not found', HttpStatus.NOT_ACCEPTABLE);
+    return await this.groupService.find({
+      where: { turnId, active: false },
+    });
+  }
+
   private async findGroup(groupId: number, findOptions: FindOneOptions<Group>) {
     const groupFound = await this.groupService.findOne(findOptions);
     if (!groupFound)


### PR DESCRIPTION


**This PR Addresses:**  
[Obtener todos los grupos con el turnoId inactivos](https://trello.com/c/CI9ETqAY/31-obtener-todos-los-grupos-con-el-turnoid-inactivos)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>