### PR TITLE
get inactive groups with turn

### DIFF
--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -35,6 +35,11 @@ export class GroupsController {
     return this.groupsProvider.getGroupsWithTurn();
   }
 
+  @Get('/turn/inactive')
+  getInactiveGroupsWithTurn() {
+    return this.groupsProvider.getInactiveGroupsWithTurn();
+  }
+
   @Get('/turn/:id')
   getGroupsWithTurnid(@Param('id') turnId: number) {
     return this.groupsProvider.getGroupsWithTurnid(turnId);

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -28,7 +28,7 @@ export class GroupsProvider {
     return await this.groupService.find({ relations: ['turn'] });
   }
 
-  async findGroupWithTurnid(
+  async findGroupsWithTurnid(
     turnId: number,
     findOptions: FindManyOptions<Group>,
   ) {
@@ -39,20 +39,27 @@ export class GroupsProvider {
   }
 
   async getGroupsWithTurnid(turnId: number) {
-    return await this.findGroupWithTurnid(turnId, {
+    return await this.findGroupsWithTurnid(turnId, {
       where: { turnId },
     });
   }
 
   async getActiveGroupsWithTurnid(turnId: number) {
-    return await this.findGroupWithTurnid(turnId, {
+    return await this.findGroupsWithTurnid(turnId, {
       where: { turnId, active: true },
     });
   }
 
   async getInactiveGroupsWithTurnid(turnId: number) {
-    return await this.findGroupWithTurnid(turnId, {
+    return await this.findGroupsWithTurnid(turnId, {
       where: { turnId, active: false },
+    });
+  }
+
+  async getInactiveGroupsWithTurn() {
+    return await this.groupService.find({
+      where: { active: false },
+      relations: ['turn'],
     });
   }
 


### PR DESCRIPTION


**This PR Addresses:**  
[Obtener todos los grupos inactivos con relacion turno](https://trello.com/c/RL5Ch84n/21-obtener-todos-los-grupos-inactivos-con-relacion-turno)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>